### PR TITLE
chore: drop the last digit from version number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [pre-commit] for instructions
 Sample `.pre-commit-config.yaml`:
 ```yaml
 - repo: https://github.com/iddinkgroup/pre-commit-mirrors-trivy
-  rev: v0.69.2.0
+  rev: v0.69.2
   hooks:
     - id: trivy-fs
       args:


### PR DESCRIPTION
This existed in the first place whereas it indicated if the repository had changes, unrelated to the trivy feature set. Dropped the digit, mainly because we saw some unexpected behavior with Renovate couldn't really determine a new version without having to customize the Renovate config. Also, probably not need the extra indication. When having changes without any new features for the end user. It isn't necessary to release a new version either