### PR TITLE
chore: update to version 0.69.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [pre-commit] for instructions
 Sample `.pre-commit-config.yaml`:
 ```yaml
 - repo: https://github.com/iddinkgroup/pre-commit-mirrors-trivy
-  rev: v0.69.2.0
+  rev: v0.69.3
   hooks:
     - id: trivy-fs
       args:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,40 +3,40 @@ download_scripts =
     [trivy]
     group = trivy-binary
     marker = sys_platform == "linux" and platform_machine == "x86_64"
-    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.2/trivy_0.69.2_Linux-64bit.tar.gz
-    sha256 = affa59a1e37d86e4b8ab2cd02f0ab2e63d22f1bf9cf6a7aa326c884e25e26ce3
+    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_Linux-64bit.tar.gz
+    sha256 = 1816b632dfe529869c740c0913e36bd1629cb7688bd5634f4a858c1d57c88b75
     extract = tar
     extract_path = trivy
 
     [trivy]
     group = trivy-binary
     marker = sys_platform == "linux" and platform_machine == "aarch64"
-    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.2/trivy_0.69.2_Linux-ARM64.tar.gz
-    sha256 = c73b97699c317b0d25532b3f188564b4e29d13d5472ce6f8eb078082546a6481
+    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz
+    sha256 = 7e3924a974e912e57b4a99f65ece7931f8079584dae12eb7845024f97087bdfd
     extract = tar
     extract_path = trivy
 
     [trivy]
     group = trivy-binary
     marker = sys_platform == "linux" and platform_machine == "armv7l"
-    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.2/trivy_0.69.2_Linux-ARM.tar.gz
-    sha256 = 4f36230491a5724dd13b9e5891728f384e508c34df53c4514acf1877b7bcd281
+    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_Linux-ARM.tar.gz
+    sha256 = d76d7c30829af5349aa2461f6703c56b3e392f7de691a231850c9a4e57827c2b
     extract = tar
     extract_path = trivy
 
     [trivy]
     group = trivy-binary
     marker = sys_platform == "darwin" and platform_machine == "arm64"
-    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.2/trivy_0.69.2_macOS-ARM64.tar.gz
-    sha256 = 320c0e6af90b5733b9326da0834240e944c6f44091e50019abdf584237ff4d0c
+    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_macOS-ARM64.tar.gz
+    sha256 = a2f2179afd4f8bb265ca3c7aefb56a666bc4a9a411663bc0f22c3549fbc643a5
     extract = tar
     extract_path = trivy
 
     [trivy]
     group = trivy-binary
     marker = sys_platform == "darwin" and platform_machine == "x86_64"
-    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.2/trivy_0.69.2_macOS-64bit.tar.gz
-    sha256 = 41f6eac3ebe3a00448a16f08038b55ce769fe2d5128cb0d64bdf282cdad4831a
+    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_macOS-64bit.tar.gz
+    sha256 = fec4a9f7569b624dd9d044fca019e5da69e032700edbb1d7318972c448ec2f4e
     extract = tar
     extract_path = trivy
 
@@ -44,7 +44,7 @@ download_scripts =
     group = trivy-binary
     marker = sys_platform == "win32" and platform_machine == "AMD64"
     marker = sys_platform == "cygwin" and platform_machine == "x86_64"
-    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.2/trivy_0.69.2_windows-64bit.zip
-    sha256 = d772fa7c3c1bc52d2914ff78107596fbd20010b5f18bec6f39d63ee3bb31ad45
+    url = https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_windows-64bit.zip
+    sha256 = 74362dc711383255308230ecbeb587eb1e4e83a8d332be5b0259afac6e0c2224
     extract = zip
     extract_path = trivy.exe


### PR DESCRIPTION
also drop the last digit of version. This existed in the first place whereas it indicated if the repository had changes, unrelated to the trivy feature set. Dropped the digit, mainly because we saw some unexpected behavior with Renovate couldn't really determine a new version without having to customize the Renovate config. Also, probably not need the extra indication. When having changes without any new features for the end user. It isn't necessary to release a new version either